### PR TITLE
fix: :bug: Corrigido bug em que o arco continuava equipado apos ser g…

### DIFF
--- a/src/BowInput.cpp
+++ b/src/BowInput.cpp
@@ -162,7 +162,13 @@ namespace {
                 equipMgr->EquipObject(player, st.prevLeft, nullptr, 1, nullptr, true, true, true, false);
             }
 
+            if (!st.prevRight && !st.prevLeft && st.chosenBow) {
+                equipMgr->UnequipObject(player, st.chosenBow, nullptr, 1, nullptr, true, true, true, false, nullptr);
+            }
+
             st.isUsingBow = false;
+            st.prevRight = nullptr;
+            st.prevLeft = nullptr;
         }
     };
 }


### PR DESCRIPTION
…uardado caso não tivesse armas equipadas antes de sacar o arco

## Summary by Sourcery

Bug Fixes:
- Ensure the bow is unequipped when stowing it if no weapons were equipped before drawing