### PR TITLE
feat: :sparkles: Salva o arco escolhido no ini; Altera a estrutura do…

### DIFF
--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -50,6 +50,9 @@ namespace IntegratedBow {
 
         const int btn = _getInt(ini, "Input", "GamepadButton", -1);
         gamepadButton.store(btn, std::memory_order_relaxed);
+
+        const int bow = _getInt(ini, "Bow", "ChosenBowFormID", 0);
+        chosenBowFormID.store(static_cast<std::uint32_t>(bow), std::memory_order_relaxed);
     }
 
     void BowConfig::Save() const {
@@ -65,6 +68,7 @@ namespace IntegratedBow {
         ini.SetLongValue("Input", "KeyboardScanCode",
                          static_cast<long>(keyboardScanCode.load(std::memory_order_relaxed)));
         ini.SetLongValue("Input", "GamepadButton", static_cast<long>(gamepadButton.load(std::memory_order_relaxed)));
+        ini.SetLongValue("Bow", "ChosenBowFormID", static_cast<long>(chosenBowFormID.load(std::memory_order_relaxed)));
 
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -12,6 +12,7 @@ namespace IntegratedBow {
         std::atomic<BowMode> mode{BowMode::Hold};
         std::atomic<std::uint32_t> keyboardScanCode{0x2F};
         std::atomic<int> gamepadButton{-1};
+        std::atomic<std::uint32_t> chosenBowFormID{0};
 
         void Load();
         void Save() const;

--- a/src/BowConfigPath.h
+++ b/src/BowConfigPath.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <windows.h>
+#ifdef GetObject
+    #undef GetObject
+#endif
 
 #include <filesystem>
 #include <vector>

--- a/src/BowState.h
+++ b/src/BowState.h
@@ -1,12 +1,82 @@
 #pragma once
+#include "BowConfig.h"
 #include "PCH.h"
+#include "RE/E/ExtraTextDisplayData.h"
+#include "RE/P/PlayerCharacter.h"
+#include "RE/T/TESObjectREFR.h"
 
 namespace BowState {
+    namespace detail {
+
+        inline void ApplyChosenTagToInstance(RE::TESBoundObject* base, RE::ExtraDataList* extra) {
+            if (!base || !extra) {
+                return;
+            }
+
+            const char* cstr = extra->GetDisplayName(base);
+            if (!cstr || !*cstr) {
+                return;
+            }
+
+            constexpr std::string_view tag{" (chosen)"};
+
+            std::string curName{cstr};
+            if (curName.ends_with(tag)) {
+                return;
+            }
+
+            curName += tag;
+
+            auto* tdd = extra->GetExtraTextDisplayData();
+            if (!tdd) {
+                tdd = new RE::ExtraTextDisplayData(base, 1.0f);
+                if (!tdd) {
+                    spdlog::warn("[IntegratedBow] failed to create ExtraTextDisplayData for chosen bow");
+                    return;
+                }
+                extra->Add(tdd);
+            }
+
+            tdd->SetName(curName.c_str());
+        }
+
+        inline void RemoveChosenTagFromInstance(RE::TESBoundObject* base, RE::ExtraDataList* extra) {
+            if (!base || !extra) {
+                return;
+            }
+
+            auto* tdd = extra->GetExtraTextDisplayData();
+            if (!tdd) {
+                return;
+            }
+
+            const char* cstr = tdd->GetDisplayName(base, 1.0f);
+            if (!cstr || !*cstr) {
+                return;
+            }
+
+            std::string curName = cstr;
+            constexpr std::string_view tag{" (chosen)"};
+
+            if (!curName.ends_with(tag)) {
+                return;
+            }
+
+            curName.erase(curName.size() - tag.size());
+
+            tdd->SetName(curName.c_str());
+        }
+
+    }
+    struct ChosenInstance {
+        RE::TESBoundObject* base{nullptr};
+        RE::ExtraDataList* extra{nullptr};
+    };
 
     struct IntegratedBowState {
-        RE::TESObjectWEAP* chosenBow{nullptr};
-        RE::TESBoundObject* prevRight{nullptr};
-        RE::TESBoundObject* prevLeft{nullptr};
+        ChosenInstance chosenBow{};
+        ChosenInstance prevRight{};
+        ChosenInstance prevLeft{};
         bool isUsingBow{false};
         bool isEquipingBow{false};
         bool wasCombatPosed{false};
@@ -17,39 +87,146 @@ namespace BowState {
         return s;
     }
 
-    inline void SetChosenBow(RE::TESObjectWEAP* bow) { Get().chosenBow = bow; }
+    inline void SetChosenBow(RE::TESObjectWEAP* bow, RE::ExtraDataList* extra) {
+        auto& cfg = IntegratedBow::GetBowConfig();
+        auto& st = Get();
+
+        if (RE::TESBoundObject* base = bow ? bow->As<RE::TESBoundObject>() : nullptr;
+            st.chosenBow.base == base && st.chosenBow.extra == extra) {
+            detail::RemoveChosenTagFromInstance(st.chosenBow.base, st.chosenBow.extra);
+            st.chosenBow.base = nullptr;
+            st.chosenBow.extra = nullptr;
+            cfg.chosenBowFormID.store(0u, std::memory_order_relaxed);
+        } else {
+            if (st.chosenBow.base && st.chosenBow.extra) {
+                BowState::detail::RemoveChosenTagFromInstance(st.chosenBow.base, st.chosenBow.extra);
+            }
+            st.chosenBow.base = base;
+            st.chosenBow.extra = extra;
+            detail::ApplyChosenTagToInstance(st.chosenBow.base, st.chosenBow.extra);
+
+            if (bow) {
+                cfg.chosenBowFormID.store(bow->GetFormID(), std::memory_order_relaxed);
+            } else {
+                cfg.chosenBowFormID.store(0u, std::memory_order_relaxed);
+            }
+        }
+
+        cfg.Save();
+    }
+
+    inline void LoadChosenBow(RE::TESObjectWEAP* bow) {
+        auto& st = Get();
+
+        st.chosenBow.base = nullptr;
+        st.chosenBow.extra = nullptr;
+
+        if (!bow) {
+            return;
+        }
+
+        RE::TESBoundObject* base = bow->As<RE::TESBoundObject>();
+        if (!base) {
+            return;
+        }
+
+        auto* player = RE::PlayerCharacter::GetSingleton();
+        if (!player) {
+            return;
+        }
+
+        auto inventory = player->GetInventory([&](RE::TESBoundObject& obj) { return &obj == base; });
+
+        constexpr const char* kChosenTag = " (chosen)";
+        constexpr std::size_t kTagLen = 9;
+
+        for (auto& [obj, data] : inventory) {
+            if (obj != base) {
+                continue;
+            }
+
+            auto& entryPtr = data.second;
+            RE::InventoryEntryData* entry = entryPtr.get();
+
+            if (!entry || !entry->extraLists) {
+                continue;
+            }
+
+            for (auto* extra : *entry->extraLists) {
+                if (!extra) {
+                    continue;
+                }
+
+                const char* dispName = extra->GetDisplayName(obj);
+                if (!dispName || !*dispName) {
+                    continue;
+                }
+
+                const std::size_t len = std::strlen(dispName);
+                if (len < kTagLen) {
+                    continue;
+                }
+
+                if (std::memcmp(dispName + (len - kTagLen), kChosenTag, kTagLen) == 0) {
+                    st.chosenBow.base = base;
+                    st.chosenBow.extra = extra;
+                    spdlog::info("[IntegratedBow] LoadChosenBow: found chosen instance in inventory: {}", dispName);
+                    return;
+                }
+            }
+        }
+    }
 
     inline void ClearChosenBow() {
         auto& st = Get();
-        st.chosenBow = nullptr;
+        st.chosenBow.base = nullptr;
+        st.chosenBow.extra = nullptr;
     }
 
-    inline bool isEquipingBow() { return Get().isEquipingBow; }
+    inline bool IsEquipingBow() { return Get().isEquipingBow; }
 
-    inline bool HasChosenBow() { return Get().chosenBow != nullptr; }
+    inline bool HasChosenBow() { return Get().chosenBow.base != nullptr; }
 
     inline bool IsUsingBow() { return Get().isUsingBow; }
 
     inline void SetUsingBow(bool value) { Get().isUsingBow = value; }
 
-    inline void SetPrevWeapons(RE::TESForm* right, RE::TESForm* left) {
+    inline void SetPrevWeapons(RE::TESBoundObject* rightBase, RE::ExtraDataList* rightExtra,
+                               RE::TESBoundObject* leftBase, RE::ExtraDataList* leftExtra) {
         auto& st = Get();
-        st.prevRight = right ? right->As<RE::TESBoundObject>() : nullptr;
-        st.prevLeft = left ? left->As<RE::TESBoundObject>() : nullptr;
+
+        st.prevRight.base = rightBase;
+        st.prevRight.extra = rightExtra;
+
+        st.prevLeft.base = leftBase;
+        st.prevLeft.extra = leftExtra;
     }
 
     inline void ClearPrevWeapons() {
         auto& st = Get();
-        st.prevRight = nullptr;
-        st.prevLeft = nullptr;
+
+        st.prevRight.base = nullptr;
+        st.prevRight.extra = nullptr;
+
+        st.prevLeft.base = nullptr;
+        st.prevLeft.extra = nullptr;
     }
 
     inline void Reset() {
         auto& st = Get();
-        st.chosenBow = nullptr;
-        st.prevRight = nullptr;
-        st.prevLeft = nullptr;
+
+        st.chosenBow.base = nullptr;
+        st.chosenBow.extra = nullptr;
+
+        st.prevRight.base = nullptr;
+        st.prevRight.extra = nullptr;
+
+        st.prevLeft.base = nullptr;
+        st.prevLeft.extra = nullptr;
+
         st.isUsingBow = false;
+        st.isEquipingBow = false;
+        st.wasCombatPosed = false;
     }
 
 }

--- a/src/Detours/detours.cpp
+++ b/src/Detours/detours.cpp
@@ -8,6 +8,9 @@
 //
 
 #include <Windows.h>
+#ifdef GetObject
+    #undef GetObject
+#endif
 // #define DETOUR_DEBUG 1
 #define DETOURS_INTERNAL
 #include "detours.hpp"

--- a/src/Detours/detours.hpp
+++ b/src/Detours/detours.hpp
@@ -8,6 +8,9 @@
 //
 
 #include <windows.h>
+#ifdef GetObject
+    #undef GetObject
+#endif
 #pragma once
 #ifndef _DETOURS_H_
     #define _DETOURS_H_

--- a/src/Detours/detver.hpp
+++ b/src/Detours/detver.hpp
@@ -11,6 +11,9 @@
 #include "winver.h"
 #if 0
     #include <windows.h>
+    #ifdef GetObject
+        #undef GetObject
+    #endif
 
     #include <detours.hpp>
 #else

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -17,17 +17,11 @@ namespace {
                           bool a_queueEquip, bool a_forceEquip, bool a_playSounds, bool a_applyNow) {
             if (auto const* player = RE::PlayerCharacter::GetSingleton(); player && a_actor == player) {
                 if (auto weap = a_object ? a_object->As<RE::TESObjectWEAP>() : nullptr) {
-                    if (weap->IsBow() && !BowState::isEquipingBow() && !BowState::IsUsingBow()) {
-                        BowState::SetChosenBow(weap);
+                    if (weap->IsBow() && !BowState::IsEquipingBow() && !BowState::IsUsingBow()) {
+                        BowState::SetChosenBow(weap, a_extraData);
+                        return;
+                    }
 
-                        return;
-                    }
-                    if (BowState::IsUsingBow() && weap->IsBow()) {
-                        func(a_mgr, a_actor, a_object, a_extraData, a_count, a_slot, a_queueEquip, a_forceEquip,
-                             a_playSounds, a_applyNow);
-                        BowState::SetChosenBow(weap);
-                        return;
-                    }
                     if (BowState::IsUsingBow() && !weap->IsBow()) {
                         func(a_mgr, a_actor, a_object, a_extraData, a_count, a_slot, a_queueEquip, a_forceEquip,
                              a_playSounds, a_applyNow);


### PR DESCRIPTION
… state para salvar o extra data da instancia; e adicona a string "(chosen)" ao arco escolhido

## Summary by Sourcery

Enable selection persistence and visual tagging of a chosen bow instance by tracking its extra data and persisting its FormID in the INI

New Features:
- Persist the chosen bow instance across game sessions via the INI configuration and reload it on game load
- Visually tag the chosen bow in inventory by appending " (chosen)" to its display name

Enhancements:
- Extend BowState to track both base objects and their ExtraDataList for chosen and previous weapons
- Update equip/un-equip logic to use the ExtraDataList so that specific item instances are handled correctly
- Introduce ApplyChosenTagToInstance and RemoveChosenTagFromInstance utilities to manage display name modifications

Chores:
- Undefine conflicting GetObject macros in BowConfigPath and Detours headers to avoid Windows API conflicts