### PR TITLE
fix: :bug: Corrigido situação de tentar equipar arco quando ele havia…

### DIFF
--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -76,7 +76,7 @@ namespace IntegratedBow {
     }
 
     BowConfig& GetBowConfig() {
-        static BowConfig g{};
+        static BowConfig g{};  // NOSONAR: Static state
         return g;
     }
 }

--- a/src/BowInput.cpp
+++ b/src/BowInput.cpp
@@ -78,8 +78,12 @@ namespace {
 
             auto& st = BowState::Get();
 
-            RE::TESObjectWEAP* bow = st.chosenBow.base ? st.chosenBow.base->As<RE::TESObjectWEAP>() : nullptr;
-            if (!bow) {
+            if (!BowState::EnsureChosenBowInInventory()) {
+                return;
+            }
+
+            if (RE::TESObjectWEAP const* bow = st.chosenBow.base ? st.chosenBow.base->As<RE::TESObjectWEAP>() : nullptr;
+                !bow) {
                 return;
             }
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1,5 +1,7 @@
 #include "Hooks.h"
 
+#include <type_traits>
+
 #include "BowInput.h"
 #include "BowState.h"
 #include "HookUtil.hpp"


### PR DESCRIPTION
… sido removido do inventário

## Summary by Sourcery

Ensure that the chosen bow remains in the player’s inventory before allowing equip actions, and clean up chosen-bow state and config when it’s no longer present

Bug Fixes:
- Prevent equipping a bow that has been removed from the player’s inventory by verifying its presence and clearing the chosen state when it’s missing

Enhancements:
- Introduce EnsureChosenBowInInventory to validate the chosen bow in the inventory before use
- Extend ClearChosenBow to remove the visual chosen tag and persist a reset config ID
- Refactor inventory loops for const-correctness and remove outdated logging

Chores:
- Add a NOSONAR suppression on the static config instance and include the missing <type_traits> header