### PR TITLE
feat(auto arrow): :sparkles: Automaticamente puxa a flecha ao usar o …

### DIFF
--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -13,6 +13,8 @@ namespace IntegratedBow {
         std::atomic<std::uint32_t> keyboardScanCode{0x2F};
         std::atomic<int> gamepadButton{-1};
         std::atomic<std::uint32_t> chosenBowFormID{0};
+        std::atomic<bool> autoDrawEnabled{true};
+        std::atomic<float> sheathedDelaySeconds{1.0f};
 
         void Load();
         void Save() const;

--- a/src/BowState.h
+++ b/src/BowState.h
@@ -142,6 +142,40 @@ namespace BowState {
                 tdd->SetName(curName.c_str());
             }
         }
+
+        inline RE::BSFixedString GetAttackUserEvent() {
+            static RE::BSFixedString ev{"Right Attack/Block"};
+            return ev;
+        }
+
+        constexpr std::uint32_t kAttackMouseIdCode = 0;
+
+        inline RE::ButtonEvent* MakeAttackButtonEvent(float value, float heldSecs) {
+            return RE::ButtonEvent::Create(RE::INPUT_DEVICE::kMouse, GetAttackUserEvent(), kAttackMouseIdCode, value,
+                                           heldSecs);
+        }
+
+        inline void DispatchAttackButtonEvent(RE::ButtonEvent* ev) {
+            if (!ev) {
+                return;
+            }
+
+            auto* pc = RE::PlayerControls::GetSingleton();
+            if (!pc) {
+                return;
+            }
+
+            auto* handler = pc->attackBlockHandler;
+            if (!handler) {
+                return;
+            }
+
+            if (!handler->CanProcess(ev)) {
+                return;
+            }
+
+            handler->ProcessButton(ev, &pc->data);
+        }
     }
 
     struct ChosenInstance {
@@ -156,6 +190,7 @@ namespace BowState {
         bool isUsingBow{false};
         bool isEquipingBow{false};
         bool wasCombatPosed{false};
+        bool isAutoAttackHeld{false};
     };
 
     inline IntegratedBowState& Get() {
@@ -268,6 +303,10 @@ namespace BowState {
         cfg.Save();
     }
 
+    inline bool IsAutoAttackHeld() { return Get().isAutoAttackHeld; }
+
+    inline void SetAutoAttackHeld(bool value) { Get().isAutoAttackHeld = value; }
+
     inline bool EnsureChosenBowInInventory() {
         auto const& st = Get();
 
@@ -348,6 +387,7 @@ namespace BowState {
         st.isUsingBow = false;
         st.isEquipingBow = false;
         st.wasCombatPosed = false;
+        st.isAutoAttackHeld = false;
     }
 
 }

--- a/src/UI_IntegratedBow.cpp
+++ b/src/UI_IntegratedBow.cpp
@@ -89,6 +89,40 @@ void __stdcall IntegratedBow_UI::DrawConfig() {
     }
 
     ImGui::Separator();
+
+    {
+        if (bool autoDraw = cfg.autoDrawEnabled.load(std::memory_order_relaxed); ImGui::Checkbox(
+                IntegratedBow::Strings::Get("Item_AutoDrawEnabled", "Auto draw arrow").c_str(), &autoDraw)) {
+            cfg.autoDrawEnabled.store(autoDraw, std::memory_order_relaxed);
+        }
+
+        ImGui::SameLine();
+        ImGui::TextDisabled(
+            "%s", IntegratedBow::Strings::Get(
+                      "Item_AutoDrawEnabled_Tip",
+                      "If enabled, the bow will automatically start drawing an arrow while holding the hotkey.")
+                      .c_str());
+    }
+
+    {
+        float delaySec = cfg.sheathedDelaySeconds.load(std::memory_order_relaxed);
+        ImGui::SetNextItemWidth(150.0f);
+
+        if (ImGui::InputFloat(IntegratedBow::Strings::Get("Item_sheathedDelay", "S delay (s)").c_str(), &delaySec, 0.1f,
+                              1.0f, "%.2f")) {
+            if (delaySec < 0.0f) delaySec = 0.0f;
+            cfg.sheathedDelaySeconds.store(delaySec, std::memory_order_relaxed);
+        }
+
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s",
+                            IntegratedBow::Strings::Get(
+                                "Item_sheathedDelay_Tip",
+                                "Time in seconds after releasing the key (in hold mode) for the weapon to be sheathed.")
+                                .c_str());
+    }
+
+    ImGui::Separator();
     ImGui::TextDisabled("%s", IntegratedBow::Strings::Get("Item_Tip", "Tip: -1 disables gamepad binding.").c_str());
 }
 


### PR DESCRIPTION
…arco

Tem um menu que permite configurar auto arrow e delay. Auto arrow é automaticamente atacar com o arco ao usar a hotkey. Delay é o delay após soltar para guardar o arco

## Summary by Sourcery

Add configurable automatic bow drawing and sheathing delay behavior when using the integrated bow hotkey.

New Features:
- Introduce an option to automatically start drawing an arrow while holding the integrated bow hotkey.
- Add a configurable delay before the bow is automatically sheathed after releasing the hotkey in hold mode.

Enhancements:
- Persist auto-draw and sheathing delay settings in the bow configuration file and expose them in the configuration UI.
- Refine bow state handling and input event dispatching to support auto-attack holding and safe, token-based delayed exit behavior.