### PR TITLE
fix: :bug: corrigido problema de limitar os botões do gamepad aos 30 …

### DIFF
--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -7,6 +7,8 @@ namespace BowInput {
     void SetHoldMode(bool hold);
     void SetKeyScanCodes(int k1, int k2, int k3);
     void SetGamepadButtons(int b1, int b2, int b3);
+    void RequestGamepadCapture();
+    int PollCapturedGamepadButton();
 
     class IntegratedBowInputHandler : public RE::BSTEventSink<RE::InputEvent*> {
     public:

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -14,10 +14,10 @@ namespace {
 
         static inline Fn* func{nullptr};
 
-        static void thunk(RE::ActorEquipManager* a_mgr, RE::Actor* a_actor, RE::TESBoundObject* a_object,
-                          RE::ExtraDataList* a_extraData, std::uint32_t a_count, const RE::BGSEquipSlot* a_slot,
-                          bool a_queueEquip, bool a_forceEquip, bool a_playSounds,
-                          bool a_applyNow) {  // NOSONAR: Definição do original
+        static void thunk(RE::ActorEquipManager* a_mgr, RE::Actor* a_actor,  // NOSONAR: Definição do original
+                          RE::TESBoundObject* a_object, RE::ExtraDataList* a_extraData, std::uint32_t a_count,
+                          const RE::BGSEquipSlot* a_slot, bool a_queueEquip, bool a_forceEquip, bool a_playSounds,
+                          bool a_applyNow) {
             if (auto const* player = RE::PlayerCharacter::GetSingleton(); player && a_actor == player) {
                 if (auto weap = a_object ? a_object->As<RE::TESObjectWEAP>() : nullptr) {
                     if (weap->IsBow() && !BowState::IsEquipingBow() && !BowState::IsUsingBow()) {


### PR DESCRIPTION
…primeiros números e adicionado função de auto detect

## Summary by Sourcery

Allow configuring bow hotkeys via automatic capture of the next keyboard key or gamepad button, and relax previous hard limits on input codes.

New Features:
- Add a UI option to capture the next pressed keyboard key or gamepad button and automatically assign it as the bow hotkey, replacing existing bindings.

Bug Fixes:
- Remove the previous limit that restricted configurable gamepad buttons (and keyboard scan codes) to a small numeric range so higher button/key codes can be used.
- Ensure input capture for hotkey configuration works even when menus would normally block input events.

Enhancements:
- Extend the input handling layer to support a temporary capture mode that encodes and reports the next keyboard or gamepad press back to the UI.