### PR TITLE
feat: :sparkles: implemental contexual equip

### DIFF
--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -9,6 +9,7 @@ namespace BowInput {
     void SetGamepadButtons(int b1, int b2, int b3);
     void RequestGamepadCapture();
     int PollCapturedGamepadButton();
+    bool IsHotkeyDown();
 
     class IntegratedBowInputHandler : public RE::BSTEventSink<RE::InputEvent*> {
     public:

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -21,8 +21,10 @@ namespace {
             if (auto const* player = RE::PlayerCharacter::GetSingleton(); player && a_actor == player) {
                 if (auto weap = a_object ? a_object->As<RE::TESObjectWEAP>() : nullptr) {
                     if (weap->IsBow() && !BowState::IsEquipingBow() && !BowState::IsUsingBow()) {
-                        BowState::SetChosenBow(weap, a_extraData);
-                        return;
+                        if (BowInput::IsHotkeyDown()) {
+                            BowState::SetChosenBow(weap, a_extraData);
+                            return;
+                        }
                     }
 
                     if (BowState::IsUsingBow() && !weap->IsBow()) {


### PR DESCRIPTION
para marcar a arma como secundária é preciso segurar a hotkey enquanto clica para equipar. Apenas clicar para equipar vai apenas equipar a arma.

## Summary by Sourcery

Gate bow selection behavior behind the contextual hotkey state and make hotkey press handling respect UI menu input blocking.

New Features:
- Allow marking a bow as the chosen/secondary weapon only when the bow hotkey is held during equip.

Enhancements:
- Ensure bow hotkey press and release callbacks are ignored while game input is blocked by menus.
- Simplify input event processing by removing special handling tied to capture requests.