### PR TITLE
fix: :bug: Corrigido bug de cancelar ataque caso ande durante a anima…

### DIFF
--- a/src/BowConfigPath.h
+++ b/src/BowConfigPath.h
@@ -14,7 +14,7 @@ namespace IntegratedBow {
 
             if (!::GetModuleHandleExW(
                     GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                    reinterpret_cast<LPCWSTR>(&GetThisDllDir), &hMod)) {
+                    reinterpret_cast<LPCWSTR>(&GetThisDllDir), &hMod)) {  // NOSONAR - conversão de ponteiro
                 return std::filesystem::current_path();
             }
 

--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -1,8 +1,28 @@
 #pragma once
+#include <atomic>
 
 namespace BowInput {
     inline constexpr int kMaxComboKeys = 3;
+    struct GlobalState {
+        bool g_holdMode = true;
+        std::array<int, BowInput::kMaxComboKeys> g_bowKeyScanCodes = {0x2F, -1, -1};
+        std::array<bool, BowInput::kMaxComboKeys> g_bowKeyDown = {false, false, false};
+        std::array<int, BowInput::kMaxComboKeys> g_bowPadButtons = {-1, -1, -1};
+        std::array<bool, BowInput::kMaxComboKeys> g_bowPadDown = {false, false, false};
+        bool g_kbdComboDown = false;
+        bool g_padComboDown = false;
+        bool g_hotkeyDown = false;
+        std::atomic_uint64_t g_exitToken{0};
+        std::atomic_bool g_captureRequested{false};
+        std::atomic_int g_capturedEncoded{-1};
+        std::atomic_bool g_attackHoldActive{false};
+        std::atomic<float> g_attackHoldSecs{0.0f};
+        std::atomic_bool g_pendingRestoreAfterSheathe{false};
+    };
+
+    GlobalState& Globals() noexcept;
     void RegisterInputHandler();
+    void RegisterAnimEventSink();
 
     void SetHoldMode(bool hold);
     void SetKeyScanCodes(int k1, int k2, int k3);
@@ -18,7 +38,7 @@ namespace BowInput {
                                               RE::BSTEventSource<RE::InputEvent*>*) override;
 
     private:
-        static void ScheduleExitBowMode(bool waitBowDraw, int delayMs);
+        static void ScheduleExitBowMode(bool waitForEquip, int delayMs);
         static void ScheduleAutoAttackDraw();
         void UpdateHotkeyState(RE::PlayerCharacter* player, bool newKbdCombo, bool newPadCombo) const;
         void HandleKeyboardButton(const RE::ButtonEvent* a_event, RE::PlayerCharacter* player) const;
@@ -32,5 +52,13 @@ namespace BowInput {
                                  BowState::IntegratedBowState& st);
         static void ExitBowMode(RE::PlayerCharacter* player, RE::ActorEquipManager* equipMgr,
                                 BowState::IntegratedBowState& st);
+    };
+
+    class BowAnimEventSink : public RE::BSTEventSink<RE::BSAnimationGraphEvent> {
+    public:
+        static BowAnimEventSink* GetSingleton();
+
+        RE::BSEventNotifyControl ProcessEvent(const RE::BSAnimationGraphEvent* a_event,
+                                              RE::BSTEventSource<RE::BSAnimationGraphEvent>* a_source) override;
     };
 }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -40,6 +40,7 @@ namespace {
             IntegratedBow_UI::Register();
         }
         if (message->type == SKSE::MessagingInterface::kPostLoadGame) {
+            BowInput::RegisterAnimEventSink();
             auto const& cfg = IntegratedBow::GetBowConfig();
             const auto bowID = cfg.chosenBowFormID.load(std::memory_order_relaxed);
             if (bowID != 0) {


### PR DESCRIPTION
…ção de pegar a flecha

Foi reescrito tudo para remover ao maximo as threads e usar eventos de animação para controlar os estados.

## Summary by Sourcery

Refactor bow input handling to use centralized global state, animation events, and synthetic input dispatching to fix auto-attack cancellation when moving and improve bow equip/unequip behavior.

Bug Fixes:
- Prevent auto-attack from being cancelled when the player moves during bow draw and reset animations.
- Ensure previous weapons are correctly restored after sheathing the bow, even without delayed threads.

Enhancements:
- Replace scattered global variables with a BowInput::GlobalState singleton for managing input and state flags.
- Track bow equip status and pending auto-attack using new flags in BowState to better coordinate input and animation flow.
- Switch auto-attack input to be injected via a synthetic InputEvent queue processed by a hook in the input polling path instead of direct handler calls.
- Drive bow auto-attack timing and weapon restoration from animation graph events (e.g., EnableBumper, WeaponSheathe, bowReset) instead of ad-hoc sleeps and threads.
- Simplify auto-draw scheduling so it relies on state flags and animation events rather than background timing threads.

Build:
- Suppress several static analysis warnings with targeted NOSONAR comments where interop or engine-lifetime constraints apply.