### PR TITLE
feat: :sparkles: Smart mode e refatorado exit

### DIFF
--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -56,6 +56,8 @@ namespace IntegratedBow {
         BowMode newMode = BowMode::Hold;
         if (_stricmp(modeStr.c_str(), "Press") == 0) {
             newMode = BowMode::Press;
+        } else if (_stricmp(modeStr.c_str(), "Smart") == 0) {
+            newMode = BowMode::Smart;
         }
         mode.store(newMode, std::memory_order_relaxed);
 
@@ -116,13 +118,26 @@ namespace IntegratedBow {
     }
 
     void BowConfig::Save() const {
+        using enum BowMode;
         CSimpleIniA ini;
         ini.SetUnicode();
         const auto path = IniPath();
         ini.LoadFile(path.string().c_str());
 
         const auto m = mode.load(std::memory_order_relaxed);
-        const char* modeStr = (m == BowMode::Press) ? "Press" : "Hold";
+        const char* modeStr = nullptr;
+        switch (m) {
+            case Press:
+                modeStr = "Press";
+                break;
+            case Smart:
+                modeStr = "Smart";
+                break;
+            case Hold:
+            default:
+                modeStr = "Hold";
+                break;
+        }
 
         ini.SetValue("Input", "Mode", modeStr);
         const int k1 = keyboardScanCode1.load(std::memory_order_relaxed);

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -6,6 +6,7 @@ namespace IntegratedBow {
     enum class BowMode : std::uint32_t {
         Hold = 0,
         Press = 1,
+        Smart = 2,
     };
 
     struct BowConfig {

--- a/src/BowState.h
+++ b/src/BowState.h
@@ -1,12 +1,10 @@
 #pragma once
+#include <array>
 #include <mutex>
 #include <queue>
 
 #include "BowConfig.h"
 #include "PCH.h"
-#include "RE/E/ExtraTextDisplayData.h"
-#include "RE/P/PlayerCharacter.h"
-#include "RE/T/TESObjectREFR.h"
 
 namespace RE {
     class InputEvent;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -63,8 +63,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* sks
     cfg.Load();
     IntegratedBow::Strings::Load();
 
-    const bool hold = (cfg.mode.load(std::memory_order_relaxed) == IntegratedBow::BowMode::Hold);
-    BowInput::SetHoldMode(hold);
+    BowInput::SetMode(std::to_underlying(cfg.mode.load(std::memory_order_relaxed)));
     BowInput::SetKeyScanCodes(cfg.keyboardScanCode1.load(std::memory_order_relaxed),
                               cfg.keyboardScanCode2.load(std::memory_order_relaxed),
                               cfg.keyboardScanCode3.load(std::memory_order_relaxed));


### PR DESCRIPTION
Adicionei o smart mode que é a combinação dos modos press e hold. Pressionar usa o arco no modo press. Segurar usa o arco no modo hold. Além disso refatorei o scheledule exit para não ter thread. Agora é usado uma máquina de estados no process event.

## Summary by Sourcery

Add a new smart bow input mode combining press and hold behaviors while refactoring input state handling and bow exit scheduling into structured, frame-driven logic.

New Features:
- Introduce a smart bow input mode that interprets quick taps as press mode and longer holds as hold mode, configurable via the UI and INI settings.

Enhancements:
- Refactor global bow input state into structured sub-states for hotkeys, capture, attack hold, modes, exit handling, and restoration flags.
- Replace threaded bow exit scheduling with a tokenized, state-machine style update processed each frame through the input event loop.
- Extract helper methods for processing input events, button handling, delta time calculation, and exit workflow to clarify responsibilities and flow control.
- Extend the UI bow mode selector and config save/load logic to support the new smart mode option alongside hold and press.