### PR TITLE
fix: :bug: Corrigido bug em que o personagem ficava bloqueando com o …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_commonlibsse_plugin(${PROJECT_NAME}
     src/BowConfig.cpp
     src/BowStrings.cpp
     src/UI_IntegratedBow.cpp
+    src/patchs/UnMapBlock.cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -41,6 +42,7 @@ target_precompile_headers(${PROJECT_NAME} PRIVATE
   src/BoWConfigPath.h
   src/BowStrings.h
   src/UI_IntegratedBow.h
+  src/patchs/UnMapBlock.h
 )
 
 set_source_files_properties(

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<YOUR CONTACT INFO HERE>.
+<igoralbquerque102@hotmail.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 <YOUR NAME HERE>
+Copyright (c) 2023 Igor Alan Albuquerque de Sousa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@ SOFTWARE.
 
 (You may remove the license below, if desired. No attribution is necessary.)
 
-This template was created from https://github.com/SkyrimDev
-Released under the BSD Zero Clause License https://opensource.org/licenses/0BSD
+This template was created from <https://github.com/SkyrimDev>
+Released under the BSD Zero Clause License <https://opensource.org/licenses/0BSD>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
-# SKSE "Hello, world!"
-
-Very simple C++ SKSE plugin for Skyrim!
-
----
-
-- [SKSE "Hello, world!"](#skse-hello-world)
-- [What does it do?](#what-does-it-do)
-- [CommonLibSSE NG](#commonlibsse-ng)
-- [Requirements](#requirements)
-  - [Opening the project](#opening-the-project)
-- [Project setup](#project-setup)
-  - [Finding Your "`mods`" Folder](#finding-your-mods-folder)
-- [Setup your own repository](#setup-your-own-repository)
-- [Sharing is Caring](#sharing-is-caring)
-
-# What does it do?
-
-After running Skyrim, once at the Main Menu, press the `~` key to open the game console.
-
-You will see that we printed `"Hello, world!"` to the console at the Main Menu 🐉
-
-# CommonLibSSE NG
-
-Because this uses [CommonLibSSE NG](https://github.com/CharmedBaryon/CommonLibSSE-NG), it supports Skyrim SE, AE, GOG, and VR.
-
-[CommonLibSSE NG](https://github.com/CharmedBaryon/CommonLibSSE-NG) is a fork of the popular [powerof3 fork](https://github.com/powerof3/CommonLibSSE) of the _original_ `CommonLibSSE` library created by [Ryan McKenzie](https://github.com/Ryan-rsm-McKenzie) in [2018](https://github.com/Ryan-rsm-McKenzie/CommonLibSSE/commit/224773c424bdb8e36c761810cdff0fcfefda5f4a).
-
 # Requirements
 
 - [Visual Studio 2022](https://visualstudio.microsoft.com/) (_the free Community edition_)
@@ -41,6 +13,7 @@ Because this uses [CommonLibSSE NG](https://github.com/CharmedBaryon/CommonLibSS
 ## Opening the project
 
 Once you have Visual Studio 2022 installed, you can open this folder in basically any C++ editor, e.g. [VS Code](https://code.visualstudio.com/) or [CLion](https://www.jetbrains.com/clion/) or [Visual Studio](https://visualstudio.microsoft.com/)
+>
 - > _for VS Code, if you are not automatically prompted to install the [C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extensions, please install those and then close VS Code and then open this project as a folder in VS Code_
 
 You may need to click `OK` on a few windows, but the project should automatically run CMake!
@@ -80,26 +53,3 @@ In Mod Organizer 2:
 In Vortex:
 
 <img src="https://raw.githubusercontent.com/SkyrimDev/Images/main/images/screenshots/Vortex/VortexSettingsModsFolder.png" height="150">
-
-# Setup your own repository
-
-If you clone this template on GitHub, please:
-
-- Go into `LICENSE` and change the year and change `<YOUR NAME HERE>` to your name.
-- Go into `CODE_OF_CONDUCT.md` and change `<YOUR CONTACT INFO HERE>` to your contact information.
-
-The `LICENSE` defaults to using the [MIT License](https://choosealicense.com/licenses/mit/), a permissive license which is used by many popular Skyrim mods (_including [CommonLibSSE](https://github.com/Ryan-rsm-McKenzie/CommonLibSSE)_).
-
-The `CODE_OF_CONDUCT.md` defaults to using the [Contributor Covenant](https://www.contributor-covenant.org/), the most popular code of conduct for open source communities.
-
-If you'd like to know more about open source licenses, see:
-- [Licensing a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository)
-- [Choose an open source license](https://choosealicense.com/)
-
-# Sharing is Caring
-
-**If you use this template, PLEASE release your project as a public open source project.** 💖
-
-**Please do not release your SKSE plugin on Nexus/etc without making the source code available** \*
-
-> \* _You do you. But please help our community by sharing your source `<3`_

--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -115,6 +115,8 @@ namespace IntegratedBow {
 
             sheathedDelaySeconds.store(delay, std::memory_order_relaxed);
         }
+
+        noLeftBlockPatch = _getBool(ini, "Patches", "NoLeftBlockPatch", false);
     }
 
     void BowConfig::Save() const {
@@ -163,6 +165,11 @@ namespace IntegratedBow {
                            static_cast<double>(sheathedDelaySeconds.load(std::memory_order_relaxed)));
 
         std::error_code ec;
+        std::filesystem::create_directories(path.parent_path(), ec);
+        ini.SaveFile(path.string().c_str());
+
+        ini.SetBoolValue("Patches", "NoLeftBlockPatch", noLeftBlockPatch);
+
         std::filesystem::create_directories(path.parent_path(), ec);
         ini.SaveFile(path.string().c_str());
     }

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -23,6 +23,7 @@ namespace IntegratedBow {
         std::atomic<std::uint32_t> chosenBowFormID{0};
         std::atomic<bool> autoDrawEnabled{true};
         std::atomic<float> sheathedDelaySeconds{1.0f};
+        bool noLeftBlockPatch = false;
 
         void Load();
         void Save() const;

--- a/src/BowConfigPath.h
+++ b/src/BowConfigPath.h
@@ -9,7 +9,7 @@
 
 namespace IntegratedBow {
     inline const std::filesystem::path& GetThisDllDir() {
-        static std::filesystem::path cached = []() {
+        static std::filesystem::path cached = []() {  // NOSONAR
             HMODULE hMod = nullptr;
 
             if (!::GetModuleHandleExW(

--- a/src/UI_IntegratedBow.h
+++ b/src/UI_IntegratedBow.h
@@ -1,6 +1,8 @@
 #pragma once
 
 namespace IntegratedBow_UI {
-    void __stdcall DrawConfig();
+    void __stdcall DrawInputTab();
+    void __stdcall DrawBowTab();
+    void __stdcall DrawPatchesTab();
     void Register();
 }

--- a/src/patchs/UnMapBlock.cpp
+++ b/src/patchs/UnMapBlock.cpp
@@ -1,0 +1,48 @@
+#include "UnMapBlock.h"
+
+#include "../PCH.h"
+
+namespace UnMapBlock {
+    SavedLeftAttackMapping g_savedLeftAttack;
+}
+
+void UnMapBlock::SetNoLeftBlockPatch(bool patch) {
+    auto const* controlMap = RE::ControlMap::GetSingleton();
+    auto const* userEvents = RE::UserEvents::GetSingleton();
+    if (!controlMap || !userEvents) {
+        return;
+    }
+
+    const auto ctx = RE::ControlMap::InputContextID::kGameplay;
+    auto* context = controlMap->controlMap[ctx];
+    if (!context) {
+        return;
+    }
+
+    const auto devIndex = static_cast<std::size_t>(RE::INPUT_DEVICE::kGamepad);
+    auto& mappings = context->deviceMappings[devIndex];
+
+    for (auto& m : mappings) {
+        if (m.eventID == userEvents->leftAttack) {
+            if (patch) {
+                if (!g_savedLeftAttack.saved) {
+                    g_savedLeftAttack.saved = true;
+                    g_savedLeftAttack.inputKey = m.inputKey;
+                    g_savedLeftAttack.modifier = m.modifier;
+                }
+
+                m.inputKey = static_cast<std::uint16_t>(RE::ControlMap::kInvalid);
+                m.modifier = 0;
+
+                spdlog::info("[IntegratedBow] No-left-block patch ENABLED (gamepad leftAttack unmapped).");
+            } else {
+                if (g_savedLeftAttack.saved) {
+                    m.inputKey = g_savedLeftAttack.inputKey;
+                    m.modifier = g_savedLeftAttack.modifier;
+
+                    spdlog::info("[IntegratedBow] No-left-block patch DISABLED (gamepad leftAttack restored).");
+                }
+            }
+        }
+    }
+}

--- a/src/patchs/UnMapBlock.h
+++ b/src/patchs/UnMapBlock.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace UnMapBlock {
+    struct SavedLeftAttackMapping {
+        bool saved = false;
+        std::uint16_t inputKey = 0;
+        std::uint16_t modifier = 0;
+    };
+
+    extern SavedLeftAttackMapping g_savedLeftAttack;  // NOSONAR - local state
+
+    void SetNoLeftBlockPatch(bool patch);
+}

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -12,6 +12,7 @@
 #include "Hooks.h"
 #include "PCH.h"
 #include "UI_IntegratedBow.h"
+#include "patchs/UnMapBlock.h"
 
 #ifndef DLLEXPORT
     #include "REL/Relocation.h"
@@ -62,6 +63,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* sks
     auto& cfg = IntegratedBow::GetBowConfig();
     cfg.Load();
     IntegratedBow::Strings::Load();
+    UnMapBlock::SetNoLeftBlockPatch(cfg.noLeftBlockPatch);
 
     BowInput::SetMode(std::to_underlying(cfg.mode.load(std::memory_order_relaxed)));
     BowInput::SetKeyScanCodes(cfg.keyboardScanCode1.load(std::memory_order_relaxed),


### PR DESCRIPTION
…arco quando usava a arma com LT como hotkey

## Summary by Sourcery

Add configurable patch to unmap vanilla left-hand block from gamepad LT and reorganize the Integrated Bow MCM into multiple tabs while wiring the new setting through config, plugin load, and build.

New Features:
- Introduce a "no left-hand block" patch option that unmaps the vanilla leftAttack action from the gamepad LT and can be toggled at runtime via the UI.

Enhancements:
- Split the Integrated Bow configuration UI into separate Input, Bow, and Patches tabs to better organize settings.
- Wire the new no-left-block option through BowConfig load/save and initialization so its state persists across sessions.
- Include the new UnMapBlock implementation and headers in the build and precompiled headers.
- Minor cleanup to path caching and formatting hints (e.g., NOSONAR annotations).

Documentation:
- Trim template README content and personalize the Code of Conduct contact and links.