### PR TITLE
fix: :bug: Patch para permitir usar lefthand como key para usar o arco

### DIFF
--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -142,6 +142,7 @@ namespace IntegratedBow {
         }
 
         ini.SetValue("Input", "Mode", modeStr);
+
         const int k1 = keyboardScanCode1.load(std::memory_order_relaxed);
         const int k2 = keyboardScanCode2.load(std::memory_order_relaxed);
         const int k3 = keyboardScanCode3.load(std::memory_order_relaxed);
@@ -164,12 +165,9 @@ namespace IntegratedBow {
         ini.SetDoubleValue("Input", "SheathedDelaySeconds",
                            static_cast<double>(sheathedDelaySeconds.load(std::memory_order_relaxed)));
 
-        std::error_code ec;
-        std::filesystem::create_directories(path.parent_path(), ec);
-        ini.SaveFile(path.string().c_str());
-
         ini.SetBoolValue("Patches", "NoLeftBlockPatch", noLeftBlockPatch);
 
+        std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);
         ini.SaveFile(path.string().c_str());
     }

--- a/src/BowInput.cpp
+++ b/src/BowInput.cpp
@@ -338,7 +338,14 @@ void BowInput::IntegratedBowInputHandler::OnKeyPressed(RE::PlayerCharacter* play
     auto* equipMgr = RE::ActorEquipManager::GetSingleton();
     auto& ist = BowInput::Globals();
 
-    ist.exit.token.fetch_add(1, std::memory_order_acq_rel);
+    if (ist.mode.holdMode && ist.exit.pending) {
+        ist.exit.pending = false;
+        ist.exit.waitForEquip = false;
+        ist.exit.waitEquipTimer = 0.0f;
+        ist.exit.delayTimer = 0.0f;
+        ist.exit.delayMs = 0;
+    }
+
     if (!equipMgr) {
         return;
     }
@@ -512,14 +519,12 @@ void BowInput::IntegratedBowInputHandler::ExitBowMode(RE::PlayerCharacter* playe
 
 void BowInput::IntegratedBowInputHandler::ScheduleExitBowMode(bool waitForEquip, int delayMs) {
     auto& st = BowInput::Globals();
-    const auto token = st.exit.token.fetch_add(1, std::memory_order_acq_rel) + 1;
 
     st.exit.pending = true;
     st.exit.waitForEquip = waitForEquip;
     st.exit.waitEquipTimer = 0.0f;
     st.exit.delayTimer = 0.0f;
     st.exit.delayMs = delayMs;
-    st.exit.tokenSnapshot = token;
 }
 
 void BowInput::IntegratedBowInputHandler::UpdateSmartMode(RE::PlayerCharacter* player, float dt) const {

--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -35,8 +35,6 @@ namespace BowInput {
         float delayTimer = 0.0f;
         float waitEquipMax = 3.0f;
         int delayMs = 0;
-        std::atomic_uint64_t token{0};
-        std::uint64_t tokenSnapshot = 0;
     };
 
     struct GlobalState {

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -9,6 +9,13 @@
 #include "RE/I/InputEvent.h"
 
 namespace {
+    inline bool IsBowOrCrossbow(const RE::TESObjectWEAP* weap) {
+        if (!weap) {
+            return false;
+        }
+        return weap->IsBow() || weap->IsCrossbow();
+    }
+
     struct EquipObjectHook {
         using Fn = void(RE::ActorEquipManager*, RE::Actor*, RE::TESBoundObject*, RE::ExtraDataList*, std::uint32_t,
                         const RE::BGSEquipSlot*, bool, bool, bool, bool);
@@ -21,13 +28,14 @@ namespace {
             bool a_forceEquip, bool a_playSounds, bool a_applyNow) {
             if (auto const* player = RE::PlayerCharacter::GetSingleton(); player && a_actor == player) {
                 if (auto weap = a_object ? a_object->As<RE::TESObjectWEAP>() : nullptr) {
-                    if (weap->IsBow() && !BowState::IsEquipingBow() && !BowState::IsUsingBow() &&
+                    const bool isBowLike = IsBowOrCrossbow(weap);
+                    if (isBowLike && !BowState::IsEquipingBow() && !BowState::IsUsingBow() &&
                         BowInput::IsHotkeyDown()) {
                         BowState::SetChosenBow(weap, a_extraData);
                         return;
                     }
 
-                    if (BowState::IsUsingBow() && !weap->IsBow()) {
+                    if (BowState::IsUsingBow() && !isBowLike) {
                         func(a_mgr, a_actor, a_object, a_extraData, a_count, a_slot, a_queueEquip, a_forceEquip,
                              a_playSounds, a_applyNow);
                         BowState::SetUsingBow(false);

--- a/src/patchs/UnMapBlock.cpp
+++ b/src/patchs/UnMapBlock.cpp
@@ -2,9 +2,7 @@
 
 #include "../PCH.h"
 
-namespace UnMapBlock {
-    SavedLeftAttackMapping g_savedLeftAttack;
-}
+UnMapBlock::SavedLeftAttackMapping UnMapBlock::g_savedLeftAttack;
 
 void UnMapBlock::SetNoLeftBlockPatch(bool patch) {
     auto const* controlMap = RE::ControlMap::GetSingleton();
@@ -33,14 +31,10 @@ void UnMapBlock::SetNoLeftBlockPatch(bool patch) {
 
                 m.inputKey = static_cast<std::uint16_t>(RE::ControlMap::kInvalid);
                 m.modifier = 0;
-
-                spdlog::info("[IntegratedBow] No-left-block patch ENABLED (gamepad leftAttack unmapped).");
             } else {
                 if (g_savedLeftAttack.saved) {
                     m.inputKey = g_savedLeftAttack.inputKey;
                     m.modifier = g_savedLeftAttack.modifier;
-
-                    spdlog::info("[IntegratedBow] No-left-block patch DISABLED (gamepad leftAttack restored).");
                 }
             }
         }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -43,8 +43,8 @@ namespace {
         if (message->type == SKSE::MessagingInterface::kPostLoadGame) {
             BowInput::RegisterAnimEventSink();
             auto const& cfg = IntegratedBow::GetBowConfig();
-            const auto bowID = cfg.chosenBowFormID.load(std::memory_order_relaxed);
-            if (bowID != 0) {
+
+            if (const auto bowID = cfg.chosenBowFormID.load(std::memory_order_relaxed); bowID != 0) {
                 auto* bow = RE::TESForm::LookupByID<RE::TESObjectWEAP>(bowID);
                 if (bow) {
                     BowState::LoadChosenBow(bow);
@@ -52,6 +52,7 @@ namespace {
                     spdlog::warn("IntegratedBow: saved bow FormID 0x{:08X} not found, ignoring", bowID);
                 }
             }
+            UnMapBlock::SetNoLeftBlockPatch(cfg.noLeftBlockPatch);
         }
     }
 }
@@ -63,7 +64,6 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* sks
     auto& cfg = IntegratedBow::GetBowConfig();
     cfg.Load();
     IntegratedBow::Strings::Load();
-    UnMapBlock::SetNoLeftBlockPatch(cfg.noLeftBlockPatch);
 
     BowInput::SetMode(std::to_underlying(cfg.mode.load(std::memory_order_relaxed)));
     BowInput::SetKeyScanCodes(cfg.keyboardScanCode1.load(std::memory_order_relaxed),


### PR DESCRIPTION
## Summary by Sourcery

Allow bow mode hotkey to work with left-hand equipped bows/crossbows and streamline exit/patch handling.

Bug Fixes:
- Treat crossbows the same as bows when handling equip logic and bow mode state.
- Reset bow exit state correctly in hold mode instead of relying on an exit token mechanism.
- Persist the NoLeftBlockPatch configuration flag properly and apply the patch after game load instead of only at plugin load.
- Ensure the saved left attack mapping symbol is correctly defined within the UnMapBlock namespace.

Enhancements:
- Simplify bow exit scheduling state by removing unused token-based synchronization fields.