### PR TITLE
fix: :bug: Agora usar o R no modo arco vai guardar o arco e restaurar…

### DIFF
--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -90,6 +90,7 @@ namespace BowInput {
         void ProcessButtonEvent(const RE::ButtonEvent* button, RE::PlayerCharacter* player) const;
         void ProcessInputEvents(RE::InputEvent* const* a_events, RE::PlayerCharacter* player) const;
         float CalculateDeltaTime() const;
+        void ResetExitState() const;
     };
 
     class BowAnimEventSink : public RE::BSTEventSink<RE::BSAnimationGraphEvent> {


### PR DESCRIPTION
… as armas anteriores

## Summary by Sourcery

Ensure bow mode exit correctly restores or unequips weapons and centralize exit state resetting.

Bug Fixes:
- Fix bow exit behavior so that using the bow hotkey in arc mode restores previously equipped weapons and unequips the temporary bow when appropriate.
- Prevent crashes or inconsistent behavior by adding null checks for player and equipment manager before restoring or unequipping weapons.
- Ensure bow usage state and previous-weapon state are cleared consistently after exiting bow mode.

Enhancements:
- Introduce a shared helper to reset bow exit state and reuse it in input handlers to reduce duplication and keep exit logic consistent.