### PR TITLE
fix: :bug: Corrigido problema de alguns tipos de armas continuarem eq…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_commonlibsse_plugin(${PROJECT_NAME}
     src/BowStrings.cpp
     src/UI_IntegratedBow.cpp
     src/patchs/UnMapBlock.cpp
+    src/patchs/HiddenItemsPatch.cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -43,6 +44,7 @@ target_precompile_headers(${PROJECT_NAME} PRIVATE
   src/BowStrings.h
   src/UI_IntegratedBow.h
   src/patchs/UnMapBlock.h
+  src/patchs/HiddenItemsPatch.h
 )
 
 set_source_files_properties(

--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -117,6 +117,8 @@ namespace IntegratedBow {
         }
 
         noLeftBlockPatch = _getBool(ini, "Patches", "NoLeftBlockPatch", false);
+
+        hideEquippedFromJsonPatch = _getBool(ini, "Patches", "HideEquippedFromJsonPatch", false);
     }
 
     void BowConfig::Save() const {
@@ -166,6 +168,10 @@ namespace IntegratedBow {
                            static_cast<double>(sheathedDelaySeconds.load(std::memory_order_relaxed)));
 
         ini.SetBoolValue("Patches", "NoLeftBlockPatch", noLeftBlockPatch);
+
+        ini.SetBoolValue("Patches", "NoLeftBlockPatch", noLeftBlockPatch);
+
+        ini.SetBoolValue("Patches", "HideEquippedFromJsonPatch", hideEquippedFromJsonPatch);
 
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -24,6 +24,7 @@ namespace IntegratedBow {
         std::atomic<bool> autoDrawEnabled{true};
         std::atomic<float> sheathedDelaySeconds{1.0f};
         bool noLeftBlockPatch = false;
+        bool hideEquippedFromJsonPatch = false;
 
         void Load();
         void Save() const;

--- a/src/BowInput.cpp
+++ b/src/BowInput.cpp
@@ -10,6 +10,7 @@
 #include "BowConfig.h"
 #include "BowState.h"
 #include "PCH.h"
+#include "patchs/HiddenItemsPatch.h"
 
 using namespace std::literals;
 
@@ -525,6 +526,10 @@ void BowInput::IntegratedBowInputHandler::EnterBowMode(RE::PlayerCharacter* play
 
     auto removed = BowState::DiffArmorSnapshot(wornBefore, wornAfter);
     BowState::SetPrevExtraEquipped(std::move(removed));
+
+    if (HiddenItemsPatch::IsEnabled()) {
+        BowState::ApplyHiddenItemsPatch(player, equipMgr, HiddenItemsPatch::GetHiddenFormIDs());
+    }
 
     if (!alreadyDrawn) {
         SetWeaponDrawn(player, true);

--- a/src/UI_IntegratedBow.cpp
+++ b/src/UI_IntegratedBow.cpp
@@ -7,6 +7,7 @@
 #include "BowStrings.h"
 #include "PCH.h"
 #include "SKSEMenuFramework.h"
+#include "patchs/HiddenItemsPatch.h"
 #include "patchs/UnMapBlock.h"
 
 using IntegratedBow::BowMode;
@@ -196,6 +197,7 @@ namespace {
                                     cfg.gamepadButton3.load(std::memory_order_relaxed));
 
         UnMapBlock::SetNoLeftBlockPatch(cfg.noLeftBlockPatch);
+        HiddenItemsPatch::SetEnabled(cfg.hideEquippedFromJsonPatch);
 
         g_pending = false;
 
@@ -242,6 +244,7 @@ namespace {
 
     void DrawPatchesSection(IntegratedBow::BowConfig& cfg, bool& dirty) {
         bool noLeftBlock = cfg.noLeftBlockPatch;
+        bool hideFromJson = cfg.hideEquippedFromJsonPatch;
 
         const auto& lbl = IntegratedBow::Strings::Get("Item_NoLeftBlockPatch", "Disable vanilla left-hand block (LT)");
         const auto& tip = IntegratedBow::Strings::Get(
@@ -256,6 +259,23 @@ namespace {
 
         ImGui::SameLine();
         ImGui::TextDisabled("%s", tip.c_str());
+
+        ImGui::Separator();
+
+        const auto& lblJson =
+            IntegratedBow::Strings::Get("Item_HideEquippedJsonPatch", "Hide extra equipped items from JSON list");
+        const auto& tipJson =
+            IntegratedBow::Strings::Get("Item_HideEquippedJsonPatch_Tip",
+                                        "When enabled, items whose FormIDs are listed in patchs/HiddenEquipped.json "
+                                        "will be unequipped while the bow is active and re-equipped on exit.");
+
+        if (ImGui::Checkbox(lblJson.c_str(), &hideFromJson)) {
+            cfg.hideEquippedFromJsonPatch = hideFromJson;
+            dirty = true;
+        }
+
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", tipJson.c_str());
     }
 }
 

--- a/src/patchs/HiddenItemsPatch.cpp
+++ b/src/patchs/HiddenItemsPatch.cpp
@@ -1,0 +1,77 @@
+#include "HiddenItemsPatch.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <string>
+
+namespace {
+    bool g_enabled = false;
+    std::vector<RE::FormID> g_formIds;
+
+    std::filesystem::path GetJsonPath() {
+        auto base = IntegratedBow::GetThisDllDir();
+        return base / "HiddenEquipped.json";
+    }
+
+    void ParseJsonLikeFile(const std::string& text, std::vector<RE::FormID>& out) {
+        out.clear();
+
+        std::regex reHex(R"(0x[0-9A-Fa-f]+)");
+        std::regex reDec(R"(\b[0-9]{1,10}\b)");
+
+        std::smatch m;
+        auto searchStart(text.cbegin());
+
+        while (std::regex_search(searchStart, text.cend(), m, reHex)) {
+            auto s = m.str();
+            auto id = static_cast<RE::FormID>(std::stoul(s, nullptr, 16));
+            out.push_back(id);
+            searchStart = m.suffix().first;
+        }
+
+        searchStart = text.cbegin();
+        while (std::regex_search(searchStart, text.cend(), m, reDec)) {
+            auto s = m.str();
+
+            if (s.size() > 2 && (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))) {
+                searchStart = m.suffix().first;
+                continue;
+            }
+            auto id = static_cast<RE::FormID>(std::stoul(s, nullptr, 10));
+            out.push_back(id);
+            searchStart = m.suffix().first;
+        }
+    }
+}
+
+void HiddenItemsPatch::LoadConfigFile() {
+    g_formIds.clear();
+
+    auto path = GetJsonPath();
+    if (!std::filesystem::exists(path)) {
+        spdlog::info("[IntegratedBow] HiddenEquipped.json not found at {}", path.string());
+        return;
+    }
+
+    std::ifstream in(path);
+    if (!in) {
+        spdlog::warn("[IntegratedBow] Failed to open {}", path.string());
+        return;
+    }
+
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    ParseJsonLikeFile(content, g_formIds);
+
+    std::sort(g_formIds.begin(), g_formIds.end());
+    g_formIds.erase(std::unique(g_formIds.begin(), g_formIds.end()), g_formIds.end());
+
+    spdlog::info("[IntegratedBow] HiddenEquipped.json loaded with {} formIDs", g_formIds.size());
+}
+
+void HiddenItemsPatch::SetEnabled(bool enabled) { g_enabled = enabled; }
+
+bool HiddenItemsPatch::IsEnabled() { return g_enabled; }
+
+const std::vector<RE::FormID>& HiddenItemsPatch::GetHiddenFormIDs() { return g_formIds; }

--- a/src/patchs/HiddenItemsPatch.h
+++ b/src/patchs/HiddenItemsPatch.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "../PCH.h"
+
+namespace HiddenItemsPatch {
+    void LoadConfigFile();
+    void SetEnabled(bool enabled);
+    bool IsEnabled();
+
+    const std::vector<RE::FormID>& GetHiddenFormIDs();
+}

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -12,6 +12,7 @@
 #include "Hooks.h"
 #include "PCH.h"
 #include "UI_IntegratedBow.h"
+#include "patchs/HiddenItemsPatch.h"
 #include "patchs/UnMapBlock.h"
 
 #ifndef DLLEXPORT
@@ -53,6 +54,7 @@ namespace {
                 }
             }
             UnMapBlock::SetNoLeftBlockPatch(cfg.noLeftBlockPatch);
+            HiddenItemsPatch::SetEnabled(cfg.hideEquippedFromJsonPatch);
         }
     }
 }
@@ -64,6 +66,8 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* sks
     auto& cfg = IntegratedBow::GetBowConfig();
     cfg.Load();
     IntegratedBow::Strings::Load();
+
+    HiddenItemsPatch::LoadConfigFile();
 
     BowInput::SetMode(std::to_underlying(cfg.mode.load(std::memory_order_relaxed)));
     BowInput::SetKeyScanCodes(cfg.keyboardScanCode1.load(std::memory_order_relaxed),


### PR DESCRIPTION
…uipadas e causarem bug visual

Foi adicionado um novo patch que permiti adicionar formID de itens que devem ser desequipados e reequipados quando usa o arco

## Summary by Sourcery

Add a configurable patch that temporarily unequips specified equipped items while the bow is active to avoid visual glitches, using FormIDs loaded from an external file.

New Features:
- Introduce a HiddenItems patch that reads a list of item FormIDs from HiddenEquipped.json and hides those items when the bow is active.

Bug Fixes:
- Prevent certain extra-equipped weapons or armors from remaining visible and causing visual glitches when using the integrated bow.

Enhancements:
- Extend bow state tracking to remember additionally unequipped items so they can be restored correctly.
- Expose the HiddenItems patch as a user-toggleable option in the in-game UI and config file.

Build:
- Add HiddenItemsPatch sources and headers to the CMake build configuration.