### PR TITLE
feat(skip equip): :sparkles: Agora é possível pular a animação de equ…

### DIFF
--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -117,6 +117,8 @@ namespace IntegratedBow {
         hideEquippedFromJsonPatch = _getBool(ini, "Patches", "HideEquippedFromJsonPatch", false);
         BlockUnequip = _getBool(ini, "Patches", "BlockPatch", false);
         noChosenTag = _getBool(ini, "Patches", "NoChosenTag", false);
+        skipEquipBowAnimationPatch.store(_getBool(ini, "Patches", "SkipEquipBowAnimationPatch", false),
+                                         std::memory_order_relaxed);
     }
 
     void BowConfig::Save() const {
@@ -161,6 +163,8 @@ namespace IntegratedBow {
         ini.SetBoolValue("Patches", "HideEquippedFromJsonPatch", hideEquippedFromJsonPatch);
         ini.SetBoolValue("Patches", "BlockPatch", BlockUnequip);
         ini.SetBoolValue("Patches", "NoChosenTag", noChosenTag);
+        ini.SetBoolValue("Patches", "SkipEquipBowAnimationPatch",
+                         skipEquipBowAnimationPatch.load(std::memory_order_relaxed));
 
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -29,6 +29,7 @@ namespace IntegratedBow {
         bool hideEquippedFromJsonPatch = false;
         bool BlockUnequip = false;
         bool noChosenTag = false;
+        std::atomic_bool skipEquipBowAnimationPatch{false};
 
         void Load();
         void Save() const;

--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -51,6 +51,9 @@ namespace BowInput {
         std::atomic_bool allowUnequip{true};
         std::atomic<std::uint64_t> allowUnequipReenableMs{0};
         std::atomic<std::uint64_t> lastHotkeyPressMs{0};
+        std::uint64_t fakeEnableBumperAtMs{0};
+        std::uint64_t disableSkipEquipToken{0};
+        std::uint64_t disableSkipEquipAtMs{0};
     };
 
     GlobalState& Globals() noexcept;

--- a/src/SaveBowDB.cpp
+++ b/src/SaveBowDB.cpp
@@ -74,8 +74,7 @@ namespace IntegratedBow {
             _bySave.try_emplace(NormalizeKey(std::string{key}), prefs);
         };
 
-        auto itSaves = j.find("saves");
-        if (itSaves != j.end() && itSaves->is_object()) {
+        if (auto itSaves = j.find("saves"); itSaves != j.end() && itSaves->is_object()) {
             for (auto it = itSaves->begin(); it != itSaves->end(); ++it) {
                 parseEntry(it.key(), it.value());
             }

--- a/src/UI_IntegratedBow.cpp
+++ b/src/UI_IntegratedBow.cpp
@@ -250,6 +250,7 @@ namespace {
         bool hideFromJson = cfg.hideEquippedFromJsonPatch;
         bool blockUnequip = cfg.BlockUnequip;
         bool noChosenTag = cfg.noChosenTag;
+        bool skipEquipBowAnim = cfg.skipEquipBowAnimationPatch.load(std::memory_order_relaxed);
 
         const auto& lbl = IntegratedBow::Strings::Get("Item_NoLeftBlockPatch", "Disable vanilla left-hand block (LT)");
         const auto& tip = IntegratedBow::Strings::Get(
@@ -315,6 +316,23 @@ namespace {
 
         ImGui::SameLine();
         ImGui::TextDisabled("%s", tipNoChosenTag.c_str());
+
+        ImGui::Separator();
+
+        const auto& lblSkipEquip =
+            IntegratedBow::Strings::Get("Item_SkipEquipBowAnimPatch", "Skip bow equip animation (SkipEquipAnimation)");
+        const auto& tipSkipEquip =
+            IntegratedBow::Strings::Get("Item_SkipEquipBowAnimPatch_Tip",
+                                        "When enabled, the plugin will set behavior graph variables to skip the equip "
+                                        "animation when entering bow mode. Requires the Skip Equip Animation mod.");
+
+        if (ImGui::Checkbox(lblSkipEquip.c_str(), &skipEquipBowAnim)) {
+            cfg.skipEquipBowAnimationPatch.store(skipEquipBowAnim, std::memory_order_relaxed);
+            dirty = true;
+        }
+
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", tipSkipEquip.c_str());
     }
 }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -133,8 +133,8 @@ namespace {
                 g_currentEssPath = g_pendingEssPath;
                 g_pendingEssPath.clear();
 
-                IntegratedBow::SaveBowPrefs prefs{};
-                if (IntegratedBow::SaveBowDB::Get().TryGetNormalized(g_currentEssPath, prefs)) {
+                if (IntegratedBow::SaveBowPrefs prefs{};
+                    IntegratedBow::SaveBowDB::Get().TryGetNormalized(g_currentEssPath, prefs)) {
                     ApplyPrefsToConfig(prefs);
                 } else {
                     ApplyPrefsToConfig(IntegratedBow::SaveBowPrefs{});


### PR DESCRIPTION
…ipar o arco com suporte do mod skip equip animation

## Summary by Sourcery

Add optional integration with the Skip Equip Animation mod to allow skipping the bow equip animation when entering bow mode.

New Features:
- Introduce a configurable patch that toggles behavior-graph variables to skip the bow equip animation when entering bow mode, compatible with the Skip Equip Animation mod.

Enhancements:
- Extend bow input state and processing to temporarily enable skip-equip behavior and automatically revert it after a short delay, including a fallback animation event to keep auto-aim timing consistent.
- Expose the skip-equip bow animation option in the integrated bow ImGui configuration UI and persist it through the existing INI and per-save preferences systems.
- Apply minor C++ cleanups using if-with-initializer to simplify preference loading and save parsing paths.