### PR TITLE
feat(skip equip): :sparkles: Agora é possível pular a animação de ree…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_commonlibsse_plugin(${PROJECT_NAME}
     src/patchs/HiddenItemsPatch.cpp
     src/BowState.cpp
     src/SaveBowDB.cpp
+    src/patchs/SkipEquipController.cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -48,6 +49,7 @@ target_precompile_headers(${PROJECT_NAME} PRIVATE
   src/patchs/UnMapBlock.h
   src/patchs/HiddenItemsPatch.h
   src/SaveBowDB.h
+  src/patchs/SkipEquipController.h
 )
 
 set_source_files_properties(

--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -119,6 +119,8 @@ namespace IntegratedBow {
         noChosenTag = _getBool(ini, "Patches", "NoChosenTag", false);
         skipEquipBowAnimationPatch.store(_getBool(ini, "Patches", "SkipEquipBowAnimationPatch", false),
                                          std::memory_order_relaxed);
+        skipEquipReturnToMeleePatch.store(_getBool(ini, "Patches", "SkipEquipReturnToMeleePatch", false),
+                                          std::memory_order_relaxed);
     }
 
     void BowConfig::Save() const {
@@ -165,6 +167,8 @@ namespace IntegratedBow {
         ini.SetBoolValue("Patches", "NoChosenTag", noChosenTag);
         ini.SetBoolValue("Patches", "SkipEquipBowAnimationPatch",
                          skipEquipBowAnimationPatch.load(std::memory_order_relaxed));
+        ini.SetBoolValue("Patches", "SkipEquipReturnToMeleePatch",
+                         skipEquipReturnToMeleePatch.load(std::memory_order_relaxed));
 
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -30,6 +30,7 @@ namespace IntegratedBow {
         bool BlockUnequip = false;
         bool noChosenTag = false;
         std::atomic_bool skipEquipBowAnimationPatch{false};
+        std::atomic_bool skipEquipReturnToMeleePatch{false};
 
         void Load();
         void Save() const;

--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -52,8 +52,6 @@ namespace BowInput {
         std::atomic<std::uint64_t> allowUnequipReenableMs{0};
         std::atomic<std::uint64_t> lastHotkeyPressMs{0};
         std::uint64_t fakeEnableBumperAtMs{0};
-        std::uint64_t disableSkipEquipToken{0};
-        std::uint64_t disableSkipEquipAtMs{0};
     };
 
     GlobalState& Globals() noexcept;

--- a/src/UI_IntegratedBow.cpp
+++ b/src/UI_IntegratedBow.cpp
@@ -251,6 +251,7 @@ namespace {
         bool blockUnequip = cfg.BlockUnequip;
         bool noChosenTag = cfg.noChosenTag;
         bool skipEquipBowAnim = cfg.skipEquipBowAnimationPatch.load(std::memory_order_relaxed);
+        bool skipReturn = cfg.skipEquipReturnToMeleePatch.load(std::memory_order_relaxed);
 
         const auto& lbl = IntegratedBow::Strings::Get("Item_NoLeftBlockPatch", "Disable vanilla left-hand block (LT)");
         const auto& tip = IntegratedBow::Strings::Get(
@@ -328,6 +329,16 @@ namespace {
 
         if (ImGui::Checkbox(lblSkipEquip.c_str(), &skipEquipBowAnim)) {
             cfg.skipEquipBowAnimationPatch.store(skipEquipBowAnim, std::memory_order_relaxed);
+            dirty = true;
+        }
+
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", tipSkipEquip.c_str());
+
+        ImGui::Separator();
+
+        if (ImGui::Checkbox("Skip equip animation on return to melee", &skipReturn)) {
+            cfg.skipEquipReturnToMeleePatch.store(skipReturn, std::memory_order_relaxed);
             dirty = true;
         }
 

--- a/src/patchs/SkipEquipController.cpp
+++ b/src/patchs/SkipEquipController.cpp
@@ -1,0 +1,92 @@
+#include "SkipEquipController.h"
+
+#include <chrono>
+#include <cstdint>
+
+#include "RE/B/BSFixedString.h"
+#include "RE/P/PlayerCharacter.h"
+
+namespace {
+    struct State {
+        std::uint64_t disableAtMs{0};
+        std::uint64_t token{0};
+    };
+
+    State& GetState() {
+        static State s;  // NOSONAR
+        return s;
+    }
+
+    std::atomic<std::uint64_t> g_skipToken{0};  // NOSONAR
+
+    std::uint64_t NowMs() {
+        using namespace std::chrono;
+        return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+    }
+
+    void SetSkipVars(RE::PlayerCharacter* pc, bool enable, int loadDelayMs, bool skip3D) {
+        if (!pc) return;
+
+        (void)pc->SetGraphVariableBool("SkipEquipAnimation", enable);
+
+        if (enable) {
+            (void)pc->SetGraphVariableInt("LoadBoundObjectDelay", loadDelayMs);
+            (void)pc->SetGraphVariableBool("Skip3DLoading", skip3D);
+        } else {
+            (void)pc->SetGraphVariableInt("LoadBoundObjectDelay", 0);
+            (void)pc->SetGraphVariableBool("Skip3DLoading", false);
+        }
+    }
+}
+
+namespace IntegratedBow::SkipEquipController {
+    void Enable(RE::PlayerCharacter* pc, int loadDelayMs, bool skip3D) { SetSkipVars(pc, true, loadDelayMs, skip3D); }
+
+    void Disable(RE::PlayerCharacter* pc) { SetSkipVars(pc, false, 0, false); }
+
+    void EnableAndArmDisable(RE::PlayerCharacter* pc, int loadDelayMs, bool skip3D, std::uint64_t delayMs) {
+        const auto token = g_skipToken.fetch_add(1, std::memory_order_relaxed) + 1;
+        auto& st = GetState();
+        st.token = token;
+        st.disableAtMs = NowMs() + delayMs;
+
+        Enable(pc, loadDelayMs, skip3D);
+    }
+
+    void ArmDisable(std::uint64_t delayMs) {
+        auto& st = GetState();
+        if (st.token == 0) {
+            return;
+        }
+        st.disableAtMs = NowMs() + delayMs;
+    }
+
+    void Cancel() {
+        auto& st = GetState();
+        st.disableAtMs = 0;
+        st.token = 0;
+        g_skipToken.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void Tick() {
+        auto& st = GetState();
+        if (st.disableAtMs == 0) {
+            return;
+        }
+
+        if (const auto now = NowMs(); now < st.disableAtMs) {
+            return;
+        }
+
+        const auto token = st.token;
+        st.disableAtMs = 0;
+        st.token = 0;
+
+        if (g_skipToken.load(std::memory_order_relaxed) != token) {
+            return;
+        }
+
+        auto* pc = RE::PlayerCharacter::GetSingleton();
+        Disable(pc);
+    }
+}

--- a/src/patchs/SkipEquipController.h
+++ b/src/patchs/SkipEquipController.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <atomic>
+#include <cstdint>
+
+namespace RE {
+    class PlayerCharacter;
+}
+
+namespace IntegratedBow::SkipEquipController {
+    void Enable(RE::PlayerCharacter* pc, int loadDelayMs, bool skip3D);
+    void Disable(RE::PlayerCharacter* pc);
+
+    void EnableAndArmDisable(RE::PlayerCharacter* pc, int loadDelayMs, bool skip3D, std::uint64_t delayMs);
+
+    void ArmDisable(std::uint64_t delayMs);
+
+    void Cancel();
+
+    void Tick();
+}


### PR DESCRIPTION
…quipar a arma no retorno do arco para a arma anteriormente equipada

## Summary by Sourcery

Introduce a shared skip-equip controller and add an option to skip the equip animation when returning from bow to the previously equipped weapon.

New Features:
- Add configurable option to skip equip animations when returning from bow mode to melee weapons.

Enhancements:
- Refactor skip-equip animation timing into a centralized SkipEquipController used by bow equip and return flows.
- Expose the new skip-equip-on-return option in the integrated bow UI and persist it in the configuration system.

Build:
- Register the new SkipEquipController source and header in the CMake build and precompiled headers.