### PR TITLE
feat: :sparkles: permite sair imediatamente do modo hold + auto ataqu…

### DIFF
--- a/src/BowConfig.cpp
+++ b/src/BowConfig.cpp
@@ -121,6 +121,8 @@ namespace IntegratedBow {
                                          std::memory_order_relaxed);
         skipEquipReturnToMeleePatch.store(_getBool(ini, "Patches", "SkipEquipReturnToMeleePatch", false),
                                           std::memory_order_relaxed);
+        cancelHoldExitDelayOnAttackPatch.store(_getBool(ini, "Patches", "CancelHoldExitDelayOnAttackPatch", false),
+                                               std::memory_order_relaxed);
     }
 
     void BowConfig::Save() const {
@@ -169,6 +171,8 @@ namespace IntegratedBow {
                          skipEquipBowAnimationPatch.load(std::memory_order_relaxed));
         ini.SetBoolValue("Patches", "SkipEquipReturnToMeleePatch",
                          skipEquipReturnToMeleePatch.load(std::memory_order_relaxed));
+        ini.SetBoolValue("Patches", "CancelHoldExitDelayOnAttackPatch",
+                         cancelHoldExitDelayOnAttackPatch.load(std::memory_order_relaxed));
 
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);

--- a/src/BowConfig.h
+++ b/src/BowConfig.h
@@ -31,6 +31,7 @@ namespace IntegratedBow {
         bool noChosenTag = false;
         std::atomic_bool skipEquipBowAnimationPatch{false};
         std::atomic_bool skipEquipReturnToMeleePatch{false};
+        std::atomic_bool cancelHoldExitDelayOnAttackPatch{false};
 
         void Load();
         void Save() const;

--- a/src/BowInput.h
+++ b/src/BowInput.h
@@ -52,6 +52,10 @@ namespace BowInput {
         std::atomic<std::uint64_t> allowUnequipReenableMs{0};
         std::atomic<std::uint64_t> lastHotkeyPressMs{0};
         std::uint64_t fakeEnableBumperAtMs{0};
+        bool postExitAttackPending{false};
+        std::uint8_t postExitAttackStage{0};
+        std::uint64_t postExitAttackDownAtMs{0};
+        std::uint64_t postExitAttackUpAtMs{0};
     };
 
     GlobalState& Globals() noexcept;

--- a/src/UI_IntegratedBow.cpp
+++ b/src/UI_IntegratedBow.cpp
@@ -252,6 +252,7 @@ namespace {
         bool noChosenTag = cfg.noChosenTag;
         bool skipEquipBowAnim = cfg.skipEquipBowAnimationPatch.load(std::memory_order_relaxed);
         bool skipReturn = cfg.skipEquipReturnToMeleePatch.load(std::memory_order_relaxed);
+        bool cancelExitDelayOnAttack = cfg.cancelHoldExitDelayOnAttackPatch.load(std::memory_order_relaxed);
 
         const auto& lbl = IntegratedBow::Strings::Get("Item_NoLeftBlockPatch", "Disable vanilla left-hand block (LT)");
         const auto& tip = IntegratedBow::Strings::Get(
@@ -337,6 +338,11 @@ namespace {
 
         ImGui::Separator();
 
+        const auto& tipSkipReturn = IntegratedBow::Strings::Get(
+            "Item_SkipEquipReturnToMelee_Tip",
+            "When enabled, the plugin will also skip equip animations when restoring your previous melee weapon(s) "
+            "after exiting bow mode. Requires Skip Equip Animation.");
+
         if (ImGui::Checkbox("Skip equip animation on return to melee", &skipReturn)) {
             cfg.skipEquipReturnToMeleePatch.store(skipReturn, std::memory_order_relaxed);
             dirty = true;
@@ -344,6 +350,21 @@ namespace {
 
         ImGui::SameLine();
         ImGui::TextDisabled("%s", tipSkipEquip.c_str());
+
+        const auto& lblCancelExitDelay =
+            IntegratedBow::Strings::Get("Item_CancelHoldExitDelayOnAttackPatch", "Cancel hold exit delay on attack");
+        const auto& tipCancelExitDelay = IntegratedBow::Strings::Get(
+            "Item_CancelHoldExitDelayOnAttackPatch_Tip",
+            "In Hold + Auto mode, after releasing the hotkey there is a short grace period before "
+            "exiting. If you attack during that grace period (without re-holding the hotkey), "
+            "exit bow mode immediately.");
+
+        if (ImGui::Checkbox(lblCancelExitDelay.c_str(), &cancelExitDelayOnAttack)) {
+            cfg.cancelHoldExitDelayOnAttackPatch.store(cancelExitDelayOnAttack, std::memory_order_relaxed);
+            dirty = true;
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", tipCancelExitDelay.c_str());
     }
 }
 

--- a/src/patchs/SkipEquipController.cpp
+++ b/src/patchs/SkipEquipController.cpp
@@ -24,26 +24,29 @@ namespace {
         return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
     }
 
-    void SetSkipVars(RE::PlayerCharacter* pc, bool enable, int loadDelayMs, bool skip3D) {
+    constexpr const char* kVarSkipEquip = "SkipEquipAnimation";
+    constexpr const char* kVarLoadDelay = "LoadBoundObjectDelay";
+    constexpr const char* kVarSkip3D = "Skip3DLoading";
+
+    inline void SetSkipVars(RE::PlayerCharacter* pc, bool enable, int loadDelayMs, bool skip3D) {
         if (!pc) return;
 
-        (void)pc->SetGraphVariableBool("SkipEquipAnimation", enable);
+        (void)pc->SetGraphVariableBool(kVarSkipEquip, enable);
 
         if (enable) {
-            (void)pc->SetGraphVariableInt("LoadBoundObjectDelay", loadDelayMs);
-            (void)pc->SetGraphVariableBool("Skip3DLoading", skip3D);
+            (void)pc->SetGraphVariableInt(kVarLoadDelay, loadDelayMs);
+            (void)pc->SetGraphVariableBool(kVarSkip3D, skip3D);
         } else {
-            (void)pc->SetGraphVariableInt("LoadBoundObjectDelay", 0);
-            (void)pc->SetGraphVariableBool("Skip3DLoading", false);
+            (void)pc->SetGraphVariableInt(kVarLoadDelay, 0);
+            (void)pc->SetGraphVariableBool(kVarSkip3D, false);
         }
     }
+
 }
 
 namespace IntegratedBow::SkipEquipController {
     void Enable(RE::PlayerCharacter* pc, int loadDelayMs, bool skip3D) { SetSkipVars(pc, true, loadDelayMs, skip3D); }
-
     void Disable(RE::PlayerCharacter* pc) { SetSkipVars(pc, false, 0, false); }
-
     void EnableAndArmDisable(RE::PlayerCharacter* pc, int loadDelayMs, bool skip3D, std::uint64_t delayMs) {
         const auto token = g_skipToken.fetch_add(1, std::memory_order_relaxed) + 1;
         auto& st = GetState();


### PR DESCRIPTION
…e apertando o botão de ataque durante o delay

## Summary by Sourcery

Add an option to immediately exit Hold + Auto bow mode and trigger an attack when attacking during the hold exit grace period, and wire it through input handling, configuration, and UI while consolidating skip-equip animation control.

New Features:
- Introduce a configurable patch that cancels the Hold + Auto bow-mode exit delay and exits immediately when an attack input is pressed during the grace period, issuing a synthetic attack tap.

Enhancements:
- Route skip-equip animation graph variable handling through the shared SkipEquipController utilities instead of BowInput.
- Expose the new cancel-exit-delay-on-attack behavior as a toggleable option in the integrated bow UI and persist it via INI config load/save.