### PR TITLE
fix(ostim): :bug: corrigido bug em que o arco poderia ser equipado du…

### DIFF
--- a/src/bow_input/InputGate.cpp
+++ b/src/bow_input/InputGate.cpp
@@ -1,12 +1,48 @@
 #include "InputGate.h"
 
+#include "RE/A/ActorState.h"
 #include "RE/B/BSFixedString.h"
+#include "RE/P/PlayerCharacter.h"
 #include "RE/U/UI.h"
 
 namespace BowInput {
     bool InputGate::IsAttackEvent(std::string_view ue) noexcept {
         using namespace std::literals;
         return ue == "Left Attack Attack/Block"sv || ue == "Right Attack/Block"sv;
+    }
+
+    bool IsPlayerStateBlockingInput(RE::PlayerCharacter* player) noexcept {
+        if (!player) return false;
+
+        auto const* st = player->AsActorState();
+        if (!st) return false;
+
+        // Knocked / down / getup etc.
+        if (st->GetKnockState() != RE::KNOCK_STATE_ENUM::kNormal) {
+            return true;
+        }
+
+        // Sitting / sleeping / mounting
+
+        if (const auto sit = st->GetSitSleepState();
+            sit == RE::SIT_SLEEP_STATE::kIsSitting || sit == RE::SIT_SLEEP_STATE::kIsSleeping ||
+            sit == RE::SIT_SLEEP_STATE::kWantToSit || sit == RE::SIT_SLEEP_STATE::kWaitingForSitAnim ||
+            sit == RE::SIT_SLEEP_STATE::kWantToSleep || sit == RE::SIT_SLEEP_STATE::kWaitingForSleepAnim ||
+            sit == RE::SIT_SLEEP_STATE::kWantToWake || sit == RE::SIT_SLEEP_STATE::kWantToStand) {
+            return true;
+        }
+
+        // Bleedout/essential down etc (você já tem helper)
+        if (st->IsBleedingOut() || st->IsUnconscious()) {
+            return true;
+        }
+
+        // Diálogo "vanilla": esse flag existe no seu ActorState2
+        if (st->actorState2.talkingToPlayer) {
+            return true;
+        }
+
+        return false;
     }
 
     bool InputGate::IsInputBlockedByMenus() {
@@ -32,6 +68,8 @@ namespace BowInput {
         static const RE::BSFixedString console{"Console"};
         static const RE::BSFixedString dialogueMenu{"Dialogue Menu"};
         static const RE::BSFixedString dialogueTopicMenu{"Dialogue Topic Menu"};
+        static const RE::BSFixedString ostimMenu{"OstimSceneMenu"};
+        static const RE::BSFixedString faderMenu{"Fader Menu"};
 
         if (static const RE::BSFixedString mcm{"Mod Configuration Menu"};
             ui->IsMenuOpen(inventoryMenu) || ui->IsMenuOpen(magicMenu) || ui->IsMenuOpen(statsMenu) ||
@@ -40,7 +78,11 @@ namespace BowInput {
             ui->IsMenuOpen(craftingMenu) || ui->IsMenuOpen(giftMenu) || ui->IsMenuOpen(lockpickingMenu) ||
             ui->IsMenuOpen(sleepWaitMenu) || ui->IsMenuOpen(loadingMenu) || ui->IsMenuOpen(mainMenu) ||
             ui->IsMenuOpen(console) || ui->IsMenuOpen(mcm) || ui->IsMenuOpen(dialogueMenu) ||
-            ui->IsMenuOpen(dialogueTopicMenu)) {
+            ui->IsMenuOpen(dialogueTopicMenu) || ui->IsMenuOpen(ostimMenu) || ui->IsMenuOpen(faderMenu)) {
+            return true;
+        }
+
+        if (auto* player = RE::PlayerCharacter::GetSingleton(); IsPlayerStateBlockingInput(player)) {
             return true;
         }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -6,13 +6,13 @@
 #include <filesystem>
 #include <mutex>
 
-#include "config/BowConfig.h"
-#include "bow_input/BowInputHandler.h"
 #include "BowState.h"
-#include "menu/BowStrings.h"
 #include "Hooks.h"
 #include "PCH.h"
+#include "bow_input/BowInputHandler.h"
+#include "config/BowConfig.h"
 #include "config/SaveBowDB.h"
+#include "menu/BowStrings.h"
 #include "menu/UI_IntegratedBow.h"
 #include "patchs/HiddenItemsPatch.h"
 #include "patchs/UnMapBlock.h"


### PR DESCRIPTION
…rante as cenas ou menus do mod ostim

## Summary by Sourcery

Prevent bow input from triggering while the player is in OSTIM scenes, certain blocked states, or related menus.

Bug Fixes:
- Block bow input when OSTIM scene or fader menus are open.
- Block bow input when the player is knocked down, sitting, sleeping, in bleedout/unconscious, or in vanilla dialogue.

Enhancements:
- Align plugin includes to a consistent order in plugin.cpp.